### PR TITLE
Make it work with clover

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": ">=4.0"
     },
     "autoload": {
         "classmap": [

--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -28,6 +28,32 @@ class SolanoLabs_PHPUnit_XmlGenerator
         $domDoc->preserveWhiteSpace = false;
         $domDoc->loadXML($config->domDoc->saveXML());
 
+        // Add prefixes to filter paths
+        $filterNodes = $domDoc->getElementsByTagName('filter');
+        if (count($filterNodes)) {
+            foreach($filterNodes as $filterNode) {
+                $whitelistNodes = $filterNode->getElementsByTagName('whitelist');
+                if (count($whitelistNodes)) {
+                    foreach($whitelistNodes as $whitelistNode) {
+                        // whitelist include and eclude directories
+                        $directoryNodes = $whitelistNode->getElementsByTagName('directory');
+                        if (count($directoryNodes)) {
+                            foreach($directoryNodes as $directoryNode) {
+                                $directoryNode->nodeValue = dirname($config->domDoc->documentURI) . DIRECTORY_SEPARATOR . $directoryNode->nodeValue;
+                            }
+                        }
+                        // whitelist include and exclude files
+                        $fileNodes = $whitelistNode->getElementsByTagName('file');
+                        if (count($fileNodes)) {
+                            foreach($fileNodes as $fileNode) {
+                                $fileNode->nodeValue = dirname($config->domDoc->documentURI) . DIRECTORY_SEPARATOR . $fileNode->textContent;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
         // Remove <testsuites/> and standalone <testsuite/> nodes
         $nodes = $domDoc->getElementsByTagName('testsuites');
         if (count($nodes)) {

--- a/tests/XmlGeneratorTest.php
+++ b/tests/XmlGeneratorTest.php
@@ -25,6 +25,15 @@ class Solano_PHPUnit_Wrapper_XmlGenerator_Test extends PHPUnit_Framework_TestCas
             $this->assertTrue(in_array($node->nodeValue, $this->config->testFiles));
         }
     }
+    
+    public function testXmlGeneratorFilter()
+    {
+        $nodes = $this->xpath->query('//filter/whitelist/directory | //filter/whitelist/file | //filter/whitelist/exclude/directory | //filter/whitelist/exclude/file');
+        $this->assertEquals(4, $nodes->length);
+        foreach($nodes as $node) {
+            $this->assertEquals(preg_match("#^" . dirname($this->domDoc->documentURI) . DIRECTORY_SEPARATOR . "(.+)$#", $node->nodeValue), 1);
+        }
+    }
 
     public function testXmlGeneratorLogging()
     {

--- a/tests/_files/xml_generator.xml
+++ b/tests/_files/xml_generator.xml
@@ -9,6 +9,16 @@
       <exclude>mock_tests/exclude</exclude>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist>
+      <directory>src</directory>
+      <file>XmlGenerator.php</file>
+      <exclude>
+        <directory>fakedir</directory>
+        <file>fakefile</file>
+      </exclude>
+    </whitelist>
+  </filter>
   <logging>
     <log type="junit" target="junit.xml" logIncompleteSkipped="false"/>
   </logging>


### PR DESCRIPTION
PR is made in scope of [CISRV-2178](https://jira.slno.net/jira/browse/CISRV-2178)

This PR solving problem with relative paths in code coverage whitelist.

It is needed to allow CI users run solano-phpunit with --coverage-clover key or with coverage-clover config in phpunit.xml:

    <logging>
        <log type="coverage-clover" target="clover.xml"/>
    </logging>

It also allows users to use any version of phpunit higher than 4.0. It was successfully tested with phpunit versions 4.8.0, 5.0.10, 5.1.7, 5.2.12, 5.3.5, 5.4.8, 5.5.7, 5.6.8, 5.7.2 (latest)

[CI report for that branch](https://ec2-54-158-76-75.compute-1.amazonaws.com/reports/15411#tab=session)
