### PR TITLE
Make `phpunit_v6` branch work with PHPUnit 6!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^4.0|^5.0|^6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "classmap": [

--- a/solano.yml
+++ b/solano.yml
@@ -17,9 +17,8 @@ tests:
 php:
   php_version:
     SPLIT:
-      - '5.3'
-      - '5.5'
       - '7.0'
+      - '7.1'
 
 hooks:
   pre_setup: composer install

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -6,6 +6,15 @@
  *
  */
 
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Filter;
+use PHPUnit\Util\Printer;
+
 if (getenv('TDDIUM')):
 
 /**
@@ -16,7 +25,7 @@ if (getenv('TDDIUM')):
  * @copyright  Solano Labs https://www.solanolabs.com/
  * @link       https://www.solanolabs.com/
  */
-class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
+class SolanoLabs_PHPUnit_Listener extends Printer implements TestListener
 {
     /**
      * @var    string
@@ -65,17 +74,17 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A test started.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test)
+    public function startTest(Test $test)
     {
         if (getenv('TDDIUM')) {
             global $tddium_output_buffer;
             $tddium_output_buffer = "";
         }
-        if (!$test instanceof PHPUnit_Framework_Warning) {
+        if (!$test instanceof Warning) {
             $testcase = array('id' => '', 'address' => '', 'status' => '', 'stderr' => '', 'stdout' => '', 'file' => '');
-            if ($test instanceof PHPUnit_Framework_TestCase) {
+            if ($test instanceof TestCase) {
                 $class = new ReflectionClass($test);
                 $className = $class->getName();
                 $testName = $test->getName();
@@ -98,10 +107,10 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A test ended.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param float                  $time
+     * @param Test  $test
+     * @param float $time
      */
-    public function endTest(PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
         $testcase = $this->currentTestcase;
         if (!$testcase['status']) {
@@ -122,11 +131,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * An error occurred.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError(Test $test, Exception $e, $time)
     {   
         $this->addNonPassTest('error', $test, $e, $time);
     }
@@ -134,11 +143,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A failure occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                  $time
+     * @param Test                 $test
+     * @param AssertionFailedError $e
+     * @param float                $time
      */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
         $this->addNonPassTest('fail', $test, $e, $time);
     }
@@ -146,11 +155,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test    $test
-     * @param PHPUnit_Framework_Warning $e
-     * @param float                     $time
+     * @param Test    $test
+     * @param Warning $e
+     * @param float   $time
      */
-    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
+    public function addWarning(Test $test, Warning $e, $time)
     {
         $this->addNonPassTest('error', $test, $e, $time);
     }
@@ -158,11 +167,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * Incomplete test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addIncompleteTest(Test $test, Exception $e, $time)
     {
         $this->addNonPassTest('skip', $test, $e, $time, 'Incomplete Test: ');
     }
@@ -170,11 +179,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * Risky test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addRiskyTest(Test $test, Exception $e, $time)
     {
         $this->addNonPassTest('error', $test, $e, $time, 'Risky Test: ');
     }
@@ -182,11 +191,11 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * Skipped test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addSkippedTest(Test $test, Exception $e, $time)
     {
         if (count($this->currentTestcase)) {
             $this->addNonPassTest('skip', $test, $e, $time, 'Skipped Test: ');
@@ -201,12 +210,12 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * Add a non-passing test to the output
      *
-     * @param string                 $status
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param string                 $stderrPrefix
+     * @param string    $status
+     * @param Test      $test
+     * @param Exception $e
+     * @param string    $stderrPrefix
      */
-    private function addNonPassTest($status, PHPUnit_Framework_Test $test, Exception $e, $time, $stderrPrefix = '')
+    private function addNonPassTest($status, Test $test, Exception $e, $time, $stderrPrefix = '')
     {
         $this->currentTestcase['status'] = $status;
         $this->currentTestcase['time'] = $time;
@@ -214,7 +223,7 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
             $this->currentTestcase['stdout'] = $test->getActualOutput();
         }
         $this->currentTestcase['stderr'] = $stderrPrefix . $e->getMessage();
-        $traceback = PHPUnit_Util_Filter::getFilteredStacktrace($e, false);
+        $traceback = Filter::getFilteredStacktrace($e, false);
         // Strip path from traceback?
         for($i = 0; $i < count($traceback); $i++) {
             if (0 === strpos($traceback[$i]['file'], $this->stripPath)) {
@@ -227,9 +236,9 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A testsuite started.
      *
-     * @param PHPUnit_Framework_TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(TestSuite $suite)
     {
         $this->currentTestSuiteName = $suite->getName();
     }
@@ -237,9 +246,9 @@ class SolanoLabs_PHPUnit_Listener extends PHPUnit_Util_Printer implements PHPUni
     /**
      * A testsuite ended.
      *
-     * @param PHPUnit_Framework_TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite(TestSuite $suite)
     {
         $this->currentTestSuiteName = '';
         $this->currentTestSuiteAddress = '';

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -6,7 +6,13 @@
  *
  */
 
-use SebastianBergmann\Environment\Console;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Util\Test as TestUtil;
 
 /**
  * PHPUnit Printer for Solano-PHPUnit
@@ -17,7 +23,7 @@ use SebastianBergmann\Environment\Console;
  * @link       https://www.solanolabs.com/
  */
 
-class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
+class SolanoLabs_PHPUnit_Printer extends ResultPrinter 
 {
     /**
      * @var array
@@ -48,11 +54,11 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * An error occurred.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError(Test $test, Exception $e, $time)
     {
         $this->writeProgressWithColor('fg-red, bold', 'ERROR');
         $this->lastTestFailed = true;
@@ -64,11 +70,11 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * A failure occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                  $time
+     * @param Test                 $test
+     * @param AssertionFailedError $e
+     * @param float                $time
      */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
         $this->writeProgressWithColor('bg-red, fg-white', 'FAIL');
         $this->lastTestFailed = true;
@@ -80,11 +86,11 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test    $test
-     * @param PHPUnit_Framework_Warning $e
-     * @param float                     $time
+     * @param Test    $test
+     * @param Warning $e
+     * @param float   $time
      */
-    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
+    public function addWarning(Test $test, Warning $e, $time)
     {
         $this->writeProgressWithColor('fg-red, bold', 'WARNING');
         $this->lastTestFailed = true;
@@ -96,11 +102,11 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * Incomplete test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addIncompleteTest(Test $test, Exception $e, $time)
     {
         $this->writeProgressWithColor('fg-yellow, bold', 'INCOMPLETE');
         $this->lastTestFailed = true;
@@ -112,11 +118,11 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * Risky test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addRiskyTest(Test $test, Exception $e, $time)
     {
         $this->writeProgressWithColor('fg-yellow, bold', 'RISKY');
         $this->lastTestFailed = true;
@@ -128,16 +134,16 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * Skipped test.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param Exception              $e
-     * @param float                  $time
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addSkippedTest(Test $test, Exception $e, $time)
     {
         // PHPUnit will skip a test without "starting" or "ending" it if a dependency isn't being met.
         if ($test->getName() != $this->lastTestName) {
             $this->writeNewLine();
-            $this->writeProgressWithColor('fg-cyan, bold', 'SKIPPING: ' . PHPUnit_Util_Test::describe($test));
+            $this->writeProgressWithColor('fg-cyan, bold', 'SKIPPING: ' . TestUtil::describe($test));
             $this->writeNewLine();
             $this->writeProgress($e->getMessage());
             $this->writeNewLine();
@@ -150,14 +156,14 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * A test started.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test)
+    public function startTest(Test $test)
     {
         $this->write(
             sprintf(
                 "\nStarting test '%s'.\n",
-                PHPUnit_Util_Test::describe($test)
+                TestUtil::describe($test)
             )
         );
         $this->lastTestName = $test->getName();
@@ -166,25 +172,25 @@ class SolanoLabs_PHPUnit_Printer extends PHPUnit_TextUI_ResultPrinter
     /**
      * A test ended.
      *
-     * @param PHPUnit_Framework_Test $test
-     * @param float                  $time
+     * @param Test  $test
+     * @param float $time
      */
-    public function endTest(PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
         if (!$this->lastTestFailed) {
             $this->writeProgressWithColor('fg-green, bold', 'PASS');
         }
 
-        if ($test instanceof PHPUnit_Framework_TestCase) {
+        if ($test instanceof TestCase) {
             $this->numAssertions += $test->getNumAssertions();
-        } elseif ($test instanceof PHPUnit_Extensions_PhptTestCase) {
+        } elseif ($test instanceof PhptTestCase) {
             $this->numAssertions++;
         }
 
         $this->lastTestFailed = false;
         $this->lastTestName = '';
 
-        if ($test instanceof PHPUnit_Framework_TestCase) {
+        if ($test instanceof TestCase) {
             if (!$test->hasExpectationOnOutput()) {
                 if ($output = $test->getActualOutput()) {
                     $this->writeNewLine();

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -1,5 +1,7 @@
 <?php
-class Solano_PHPUnit_Wrapper_Command_Test extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Solano_PHPUnit_Wrapper_Command_Test extends TestCase
 {
     public function testUsage()
     {

--- a/tests/ConfigurationAlphaTest.php
+++ b/tests/ConfigurationAlphaTest.php
@@ -1,8 +1,10 @@
 <?php
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group Configuration
  */
-class Solano_PHPUnit_Wrapper_ConfigurationAlpha_Test extends PHPUnit_Framework_TestCase
+class Solano_PHPUnit_Wrapper_ConfigurationAlpha_Test extends TestCase
 {
     // Test that --alpha sorts tests in alphabetical order
     public function testAlphaOrder()

--- a/tests/ConfigurationEnumeratedFilesTest.php
+++ b/tests/ConfigurationEnumeratedFilesTest.php
@@ -1,9 +1,11 @@
 <?php
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group Configuration
  * @group ConfigurationEnumeratedFiles
  */
-class Solano_PHPUnit_Wrapper_ConfigurationEnumeratedFiles_Test extends PHPUnit_Framework_TestCase
+class Solano_PHPUnit_Wrapper_ConfigurationEnumeratedFiles_Test extends TestCase
 {
     public function testEnumerateTestFiles()
     {

--- a/tests/ConfigurationExtendedAttributesTest.php
+++ b/tests/ConfigurationExtendedAttributesTest.php
@@ -1,9 +1,11 @@
 <?php
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group Configuration
  * @group ConfigurationEnumeratedFiles
  */
-class Solano_PHPUnit_Wrapper_ConfigurationExtendedAttributes_Test extends PHPUnit_Framework_TestCase
+class Solano_PHPUnit_Wrapper_ConfigurationExtendedAttributes_Test extends TestCase
 {
     public function testExtendedAttributes()
     {

--- a/tests/ConfigurationPriorityTest.php
+++ b/tests/ConfigurationPriorityTest.php
@@ -1,8 +1,10 @@
 <?php
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group Configuration
  */
-class Solano_PHPUnit_Wrapper_ConfigurationPriority_Test extends PHPUnit_Framework_TestCase
+class Solano_PHPUnit_Wrapper_ConfigurationPriority_Test extends TestCase
 {
     // Test that 'priority' attributes in supplied phpunit.xml file result in proper ordering of tests
     public function testXmlDefinedPriority()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
-class Solano_PHPUnit_Wrapper_Configuration_Test extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Solano_PHPUnit_Wrapper_Configuration_Test extends TestCase
 {
     public function testCliBootstrap()
     {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
-class Solano_PHPUnit_Wrapper_Util_Test extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Solano_PHPUnit_Wrapper_Util_Test extends TestCase
 {
     public function testTruePath()
     {

--- a/tests/XmlGeneratorTest.php
+++ b/tests/XmlGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
-class Solano_PHPUnit_Wrapper_XmlGenerator_Test extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Solano_PHPUnit_Wrapper_XmlGenerator_Test extends TestCase
 {
     private $domDoc;
     private $xpath;


### PR DESCRIPTION
Hey @IsaacChapman,

I finally managed to get `solanolabs/solano-phpunit` working with PHPUnit 6!

As you can see, support for old PHPUnit 4 and 5 has been dropped as well as PHP 5.3 and 5.5 support.

Please, consider merging this into your `phpunit_v6` branch so we can start using this official repository rather than our fork.

This PR will fix issue #11.

Thanks!